### PR TITLE
Respect Anki “Next day starts at” cutoff in streak calculations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,176 @@
+# Created by https://www.toptal.com/developers/gitignore/api/python
+# Edit at https://www.toptal.com/developers/gitignore?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+# End of https://www.toptal.com/developers/gitignore/api/python

--- a/logic/streak_history_manager.py
+++ b/logic/streak_history_manager.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime
 from aqt import mw, gui_hooks
 from typing import Set
-from anki.consts import DAY_SECS
+#from anki.consts import DAY_SECS
 
 
 class StreakHistoryManager:
@@ -52,9 +52,32 @@ class StreakHistoryManager:
 
         for revlog_id, in result:           
             ts = revlog_id / 1000            
-            cutoff = mw.col.sched.dayCutoff
-            date_obj = datetime.fromtimestamp(ts + cutoff)
-            date_str = date_obj.strftime("%Y-%m-%d")
+            cutoff_timestamp = mw.col.sched.day_cutoff 
+            cutoff_datetime = datetime.fromtimestamp(cutoff_timestamp)
+            offset_seconds = cutoff_datetime.hour * 3600 + cutoff_datetime.minute * 60 + cutoff_datetime.second
+            
+            #anki_day = int((ts - offset_seconds) // 86400)
+            #date_str = datetime.fromtimestamp(anki_day * 86400).date().isoformat()
+            
+            #date_obj = datetime.fromtimestamp(ts - offset_seconds)
+            date_obj1 = datetime.fromtimestamp(ts)
+            date_obj2 = datetime.fromtimestamp(ts - offset_seconds)
+            #date_obj2 = mw.col.sched.date_for_timestamp(ts).isoformat()
+            #date_obj3 = mw.col.sched.date_for_timestamp(revlog_id).isoformat()
+            date_str = date_obj2.strftime("%Y-%m-%d")
+            #date_str = mw.col.sched.date_for_timestamp(ts).isoformat()
+            
+            # DEBUG:
+            #print(f"[StreakHist] revlog_id={revlog_id} ts={ts:.0f} cutoff={cutoff} "
+            #f"-> date_obj={date_obj.isoformat()} date_str={date_str}")
+            
+            #[StreakHist] revlog_id=1749445948000 ts=1749445948 cutoff=1753254000 date_obj=2025-06-08T22:12:28 date_obj1=2025-06-09T02:12:28 date_obj2=2025-06-08T22:12:28 -> date_str=2025-06-09
+            
+            if revlog_id > 1740366000000 and revlog_id < 1740452400000:
+                # DEBUG:
+                print(f"[StreakHist] revlog_id={revlog_id} ts={ts:.0f} cutoff={cutoff_timestamp} date_obj1={date_obj1.isoformat()} date_obj2={date_obj2.isoformat()}  "
+                    f"-> date_str={date_str}")
+          
             if date_str not in self.days:
                 self.days.add(date_str)
 

--- a/logic/streak_history_manager.py
+++ b/logic/streak_history_manager.py
@@ -3,8 +3,6 @@ import json
 from datetime import datetime
 from aqt import mw, gui_hooks
 from typing import Set
-#from anki.consts import DAY_SECS
-
 
 class StreakHistoryManager:
     FILENAME = "streak_history.json"
@@ -54,29 +52,9 @@ class StreakHistoryManager:
             ts = revlog_id / 1000            
             cutoff_timestamp = mw.col.sched.day_cutoff 
             cutoff_datetime = datetime.fromtimestamp(cutoff_timestamp)
-            offset_seconds = cutoff_datetime.hour * 3600 + cutoff_datetime.minute * 60 + cutoff_datetime.second
-            
-            #anki_day = int((ts - offset_seconds) // 86400)
-            #date_str = datetime.fromtimestamp(anki_day * 86400).date().isoformat()
-            
-            #date_obj = datetime.fromtimestamp(ts - offset_seconds)
-            date_obj1 = datetime.fromtimestamp(ts)
-            date_obj2 = datetime.fromtimestamp(ts - offset_seconds)
-            #date_obj2 = mw.col.sched.date_for_timestamp(ts).isoformat()
-            #date_obj3 = mw.col.sched.date_for_timestamp(revlog_id).isoformat()
-            date_str = date_obj2.strftime("%Y-%m-%d")
-            #date_str = mw.col.sched.date_for_timestamp(ts).isoformat()
-            
-            # DEBUG:
-            #print(f"[StreakHist] revlog_id={revlog_id} ts={ts:.0f} cutoff={cutoff} "
-            #f"-> date_obj={date_obj.isoformat()} date_str={date_str}")
-            
-            #[StreakHist] revlog_id=1749445948000 ts=1749445948 cutoff=1753254000 date_obj=2025-06-08T22:12:28 date_obj1=2025-06-09T02:12:28 date_obj2=2025-06-08T22:12:28 -> date_str=2025-06-09
-            
-            if revlog_id > 1740366000000 and revlog_id < 1740452400000:
-                # DEBUG:
-                print(f"[StreakHist] revlog_id={revlog_id} ts={ts:.0f} cutoff={cutoff_timestamp} date_obj1={date_obj1.isoformat()} date_obj2={date_obj2.isoformat()}  "
-                    f"-> date_str={date_str}")
+            offset_seconds = cutoff_datetime.hour * 3600 + cutoff_datetime.minute * 60 + cutoff_datetime.second          
+            date_obj = datetime.fromtimestamp(ts - offset_seconds)
+            date_str = date_obj.strftime("%Y-%m-%d")
           
             if date_str not in self.days:
                 self.days.add(date_str)

--- a/logic/streak_history_manager.py
+++ b/logic/streak_history_manager.py
@@ -3,6 +3,7 @@ import json
 from datetime import datetime
 from aqt import mw, gui_hooks
 from typing import Set
+from anki.consts import DAY_SECS
 
 
 class StreakHistoryManager:
@@ -49,8 +50,10 @@ class StreakHistoryManager:
         result = mw.col.db.all("SELECT id FROM revlog")
         current_days_count = len(self.days)
 
-        for revlog_id, in result:
-            date_obj = datetime.fromtimestamp(revlog_id / 1000)
+        for revlog_id, in result:           
+            ts = revlog_id / 1000            
+            cutoff = mw.col.sched.dayCutoff
+            date_obj = datetime.fromtimestamp(ts + cutoff)
             date_str = date_obj.strftime("%Y-%m-%d")
             if date_str not in self.days:
                 self.days.add(date_str)

--- a/logic/streak_manager.py
+++ b/logic/streak_manager.py
@@ -184,6 +184,10 @@ class StreakManager:
             if newly_earned_count > 0:
                 self.add_streak_freeze(newly_earned_count)        
 
+        if len(self.data["earned_freeze_dates"]) > self.MAX_STREAK_FREEZES:
+            self.data["earned_freeze_dates"].sort()
+            self.data["earned_freeze_dates"] = self.data["earned_freeze_dates"][-self.MAX_STREAK_FREEZES:]
+
         self.data["current_streak_length"] = calculated_streak
         # final_last_active_day_obj represents the most recent day in the streak
         self.data["last_active_day"] = final_last_active_day_obj.strftime(

--- a/logic/streak_manager.py
+++ b/logic/streak_manager.py
@@ -5,8 +5,7 @@ from typing import Union, Any, List
 import time
 
 MAX_STREAK_FREEZES = 2
-REVIEWS_PER_FREEZE = 1000
-
+DAYS_PER_FREEZE = 5
 
 class StreakManager:
     _instance = None
@@ -21,6 +20,7 @@ class StreakManager:
     def _initialize(self, main_window: AnkiQt):
         self.mw = main_window
         self.MAX_STREAK_FREEZES = MAX_STREAK_FREEZES
+        self.DAYS_PER_FREEZE = DAYS_PER_FREEZE
         self.streak_history = StreakHistoryManager()
         self.data = None
 
@@ -37,7 +37,7 @@ class StreakManager:
             "last_active_day": None,
             "earned_freeze_dates": [],
             "consumed_freeze_dates": [],
-            "reviews_since_last_freeze": 0,
+            "days_since_last_freeze": 0,
             "last_sync_reviews_today_count": 0,
             "last_sync_date": None
         }
@@ -52,7 +52,7 @@ class StreakManager:
 
         data.setdefault("earned_freeze_dates", [])
         data.setdefault("consumed_freeze_dates", [])
-        data.setdefault("reviews_since_last_freeze", 0)
+        data.setdefault("days_since_last_freeze", 0)
         data.setdefault("last_sync_reviews_today_count", 0)
         data.setdefault("last_sync_date", None)
 
@@ -168,6 +168,22 @@ class StreakManager:
             if calculated_streak > 365 * 10:
                 break
 
+        total_potential_freezes = calculated_streak // DAYS_PER_FREEZE
+
+        self.data["days_since_last_freeze"] = calculated_streak % DAYS_PER_FREEZE
+
+        consumed_count = len(self.data.get("consumed_freeze_dates", []))
+        current_available_in_data = len(self.data.get("earned_freeze_dates", []))
+        net_earned_so_far = consumed_count + current_available_in_data
+
+        if total_potential_freezes > net_earned_so_far:
+            newly_earned_count = total_potential_freezes - net_earned_so_far
+            if (current_available_in_data + newly_earned_count) > self.MAX_STREAK_FREEZES:
+                newly_earned_count = self.MAX_STREAK_FREEZES - current_available_in_data
+            
+            if newly_earned_count > 0:
+                self.add_streak_freeze(newly_earned_count)        
+
         self.data["current_streak_length"] = calculated_streak
         # final_last_active_day_obj represents the most recent day in the streak
         self.data["last_active_day"] = final_last_active_day_obj.strftime(
@@ -232,10 +248,10 @@ class StreakManager:
             self.recalculate_streak()
         return self.data["last_active_day"] if self.data else None
 
-    def get_reviews_since_last_freeze(self) -> int:
+    def get_days_since_last_freeze(self) -> int:
         if self.data is None:
             self.recalculate_streak()
-        return self.data.get("reviews_since_last_freeze", 0)
+        return self.data.get("days_since_last_freeze", 0)
 
     def has_reviewed_today(self) -> bool:
         
@@ -303,60 +319,9 @@ class StreakManager:
         return details
 
     def update_reviews_on_sync(self):
-        if self.data is None:
-            self.data = self._load_data()
-
-        ts_now = time.time()
-        cutoff_timestamp = mw.col.sched.day_cutoff 
-        cutoff_datetime = datetime.fromtimestamp(cutoff_timestamp)
-        offset_seconds = cutoff_datetime.hour * 3600 + cutoff_datetime.minute * 60 + cutoff_datetime.second
-        
-        today = datetime.fromtimestamp(ts_now - offset_seconds)
-        today_str = today.strftime("%Y-%m-%d")
-                
-        current_reviews_today = self.get_review_count_for_date(today)
-
-        last_sync_date_str = self.data.get("last_sync_date")
-        last_sync_reviews_today = self.data.get("last_sync_reviews_today_count", 0)
-
-        if last_sync_date_str == today_str:
-            new_reviews_from_sync = current_reviews_today - last_sync_reviews_today
-            if new_reviews_from_sync > 0:
-                self.data["reviews_since_last_freeze"] += new_reviews_from_sync
-        else:
-            self.data["reviews_since_last_freeze"] += current_reviews_today
-
-        self.data["last_sync_date"] = today_str
-        self.data["last_sync_reviews_today_count"] = current_reviews_today
-        self._save_data()
-
-        if self.data["reviews_since_last_freeze"] >= REVIEWS_PER_FREEZE:
-            self.add_streak_freeze(1)
-            self.data["reviews_since_last_freeze"] = 0
-            self._save_data()
-
         self.recalculate_streak()
 
     def update_streak_for_review(self, *args: Any, **kwargs: Any):
-        if self.data is None:
-            self.data = self._load_data()
-
-        ts_now = time.time()
-        cutoff_timestamp = mw.col.sched.day_cutoff 
-        cutoff_datetime = datetime.fromtimestamp(cutoff_timestamp)
-        offset_seconds = cutoff_datetime.hour * 3600 + cutoff_datetime.minute * 60 + cutoff_datetime.second
-        
-        today = datetime.fromtimestamp(ts_now - offset_seconds)
-        today_str = today.strftime("%Y-%m-%d")
-                
-        self.streak_history.add_day(today_str)
-
-        self.data["reviews_since_last_freeze"] = self.data.get("reviews_since_last_freeze", 0) + 1
-        if self.data["reviews_since_last_freeze"] >= REVIEWS_PER_FREEZE:
-            self.add_streak_freeze(1)
-            self.data["reviews_since_last_freeze"] = 0
-            self._save_data()
-
         self.recalculate_streak()
 
 _global_streak_manager_instance = None

--- a/ui/freeze_popup.py
+++ b/ui/freeze_popup.py
@@ -18,6 +18,7 @@ class FreezePopup(QDialog):
         streak_manager = get_streak_manager()
         current = streak_manager.get_streak_freezes_available()
         max_freezes = streak_manager.MAX_STREAK_FREEZES
+        days_per_freeze = streak_manager.DAYS_PER_FREEZE
 
         freeze_display_layout = QHBoxLayout()
         freeze_display_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -39,15 +40,15 @@ class FreezePopup(QDialog):
         layout.addSpacing(10)
 
         if current < max_freezes:
-            reviews = streak_manager.get_reviews_since_last_freeze()
-            progress = min(reviews, 1000)
+            days = streak_manager.get_days_since_last_freeze()
+            progress = min(days, days_per_freeze)
 
             bar = QProgressBar()
             bar.setMinimum(0)
-            bar.setMaximum(1000)
+            bar.setMaximum(days_per_freeze)
             bar.setValue(progress)
             bar.setTextVisible(True)
-            bar.setFormat(f"{reviews}/1000 reviews until next freeze")
+            bar.setFormat(f"{days}/{days_per_freeze} days until next freeze")
             bar.setAlignment(Qt.AlignmentFlag.AlignCenter)
             layout.addWidget(bar)
 


### PR DESCRIPTION
This change updates the way AnkiStreak converts raw review timestamps into calendar days so that it honors the user’s Tools → Preferences → Scheduling → Next day starts at setting (the “dayCutoff”) instead of always using midnight. Previously, any review submitted between 00:00 and the configured cutoff hour was mistakenly attributed to the previous day’s streak, leading to off‑by‑one errors in the current and longest streak counts.

Fix the https://github.com/FusionGuardian/AnkiStreak/issues/2